### PR TITLE
Add MetaDrive runtime lidar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ BridgeSim is a cross-simulator closed-loop evaluation platform for end-to-end au
 - [√] Open-loop and closed-loop evaluation modes
 - [√] Configurable traffic modes: `no_traffic`, `log_replay`, `IDM`
 - [√] Support privileged agents: `PDM-Closed`
+- [√] Optional MetaDrive runtime LiDAR sensors for closed-loop evaluation
 - [ ] Adversarial traffic mode
 - [ ] Implementation of TTA module
 
@@ -135,6 +136,40 @@ python bridgesim/evaluation/unified_evaluator.py \
 | `--consensus-temperature` | `1.0` | Placeholder for scorer module |
 
 </details>
+
+### Optional Runtime LiDAR
+
+BridgeSim can attach MetaDrive runtime LiDAR sensors during closed-loop evaluation. This LiDAR is generated from the current simulated scene, not from source-dataset logs, so it stays aligned with the simulated ego pose and replay/IDM traffic.
+
+Two runtime sensors are available:
+
+| Sensor | CLI flag | Adapter input | Notes |
+|---|---|---|---|
+| `ray_lidar` | `--enable-runtime-lidar` | Ego-frame hit points and rasterized BEV | Used by DiffusionDrive, DiffusionDriveV2, and TransFuser when enabled |
+| `point_cloud_lidar` | `--enable-runtime-point-cloud-lidar` | Ego-frame unordered points plus dense point grid | Exposed for adapters that need 3D point-cloud input |
+
+Example:
+
+```bash
+python bridgesim/evaluation/unified_evaluator.py \
+    --model-type diffusiondrive \
+    --checkpoint ckpts/BridgeSim/navsimv2/diffusiondrive \
+    --plan-anchor-path ckpts/BridgeSim/navsimv2/kmeans_navsim_traj_20.npy \
+    --scenario-path /path/to/converted/scenario \
+    --output-dir outputs/ \
+    --traffic-mode log_replay \
+    --eval-mode closed_loop \
+    --enable-runtime-lidar \
+    --runtime-lidar-num-lasers 720 \
+    --runtime-lidar-distance 50 \
+    --enable-runtime-point-cloud-lidar \
+    --runtime-point-cloud-lidar-width 200 \
+    --runtime-point-cloud-lidar-height 64 \
+    --runtime-point-cloud-lidar-fov 90 \
+    --save-runtime-lidar
+```
+
+`--save-runtime-lidar` writes per-frame `runtime_lidar.npz` files and debug views, plus final `runtime_lidar_bev.gif` and `runtime_point_cloud_lidar_sensor_view.gif`.
 
 Or run batch evaluation over all converted scenarios, please use the following sequential batch evaluation with aggregated per-scenario metrics instead of <code>batch_evaluator.py</code> as we observe that this might be too heavy-weight for some systems. Refer to [scripts/sequential_batch_eval.sh](scripts/sequential_batch_eval.sh).
 

--- a/bridgesim/evaluation/batch_evaluator.py
+++ b/bridgesim/evaluation/batch_evaluator.py
@@ -65,7 +65,16 @@ class BatchEvaluator:
                  trajectory_scorer: str = None,
                  num_groups: int = None,
                  num_proposals: int = None,
-                 v2_scorer_checkpoint: str = None):
+                 v2_scorer_checkpoint: str = None,
+                 enable_runtime_lidar: bool = False,
+                 runtime_lidar_num_lasers: int = 720,
+                 runtime_lidar_distance: float = 50.0,
+                 runtime_lidar_height: float = 1.2,
+                 enable_runtime_point_cloud_lidar: bool = False,
+                 runtime_point_cloud_lidar_width: int = 200,
+                 runtime_point_cloud_lidar_height: int = 64,
+                 runtime_point_cloud_lidar_fov: float = 90.0,
+                 save_runtime_lidar: bool = False):
         """
         Initialize batch evaluator.
 
@@ -98,6 +107,9 @@ class BatchEvaluator:
             alp_temperature: Temperature for Alpamayo generation
             alp_num_traj_samples: Number of trajectory samples for Alpamayo
             alp_max_generation_length: Max generation length for Alpamayo
+            enable_runtime_lidar: Enable MetaDrive runtime ray lidar
+            enable_runtime_point_cloud_lidar: Enable MetaDrive runtime PointCloudLidar
+            save_runtime_lidar: Save runtime lidar packets and debug visualizations
         """
         self.model_type = model_type
         self.config_path = config_path
@@ -139,6 +151,15 @@ class BatchEvaluator:
         self.num_groups = num_groups
         self.num_proposals = num_proposals
         self.v2_scorer_checkpoint = v2_scorer_checkpoint
+        self.enable_runtime_lidar = enable_runtime_lidar
+        self.runtime_lidar_num_lasers = runtime_lidar_num_lasers
+        self.runtime_lidar_distance = runtime_lidar_distance
+        self.runtime_lidar_height = runtime_lidar_height
+        self.enable_runtime_point_cloud_lidar = enable_runtime_point_cloud_lidar
+        self.runtime_point_cloud_lidar_width = runtime_point_cloud_lidar_width
+        self.runtime_point_cloud_lidar_height = runtime_point_cloud_lidar_height
+        self.runtime_point_cloud_lidar_fov = runtime_point_cloud_lidar_fov
+        self.save_runtime_lidar = save_runtime_lidar
 
         # Create output directories
         self.output_root.mkdir(parents=True, exist_ok=True)
@@ -179,6 +200,10 @@ class BatchEvaluator:
                 subdir += f"_np{self.num_proposals}"
         if self.enable_temporal_consistency:
             subdir += f"_ta{self.temporal_alpha}_th{self.temporal_max_history}"
+        if self.enable_runtime_lidar:
+            subdir += f"_runtime_lidar{self.runtime_lidar_num_lasers}"
+        if self.enable_runtime_point_cloud_lidar:
+            subdir += f"_runtime_pcl{self.runtime_point_cloud_lidar_width}x{self.runtime_point_cloud_lidar_height}"
         return subdir
 
     def evaluate_scenario(self, scenario_path: Path) -> Dict[str, Any]:
@@ -272,6 +297,20 @@ class BatchEvaluator:
             cmd.extend(["--num-proposals", str(self.num_proposals)])
         if self.v2_scorer_checkpoint:
             cmd.extend(["--v2-scorer-checkpoint", self.v2_scorer_checkpoint])
+
+        # Add runtime lidar flags
+        if self.enable_runtime_lidar:
+            cmd.append("--enable-runtime-lidar")
+            cmd.extend(["--runtime-lidar-num-lasers", str(self.runtime_lidar_num_lasers)])
+        cmd.extend(["--runtime-lidar-distance", str(self.runtime_lidar_distance)])
+        cmd.extend(["--runtime-lidar-height", str(self.runtime_lidar_height)])
+        if self.enable_runtime_point_cloud_lidar:
+            cmd.append("--enable-runtime-point-cloud-lidar")
+            cmd.extend(["--runtime-point-cloud-lidar-width", str(self.runtime_point_cloud_lidar_width)])
+            cmd.extend(["--runtime-point-cloud-lidar-height", str(self.runtime_point_cloud_lidar_height)])
+            cmd.extend(["--runtime-point-cloud-lidar-fov", str(self.runtime_point_cloud_lidar_fov)])
+        if self.save_runtime_lidar:
+            cmd.append("--save-runtime-lidar")
 
         # Add Alpamayo-specific flags
         if self.model_type == "alpamayo_r1":
@@ -592,7 +631,29 @@ def main():
                         help="Path to DiffusionDrive v2 checkpoint for loading coarse scorer weights. "
                              "Required when using --trajectory-scorer learned with DiffusionDrive v1.")
 
+    # Runtime lidar sensors
+    parser.add_argument('--enable-runtime-lidar', action='store_true',
+                        help='Enable MetaDrive runtime ray lidar and expose it in the unified lidar dict')
+    parser.add_argument('--runtime-lidar-num-lasers', type=int, default=720,
+                        help='Number of MetaDrive runtime ray lidar lasers (default: 720)')
+    parser.add_argument('--runtime-lidar-distance', type=float, default=50.0,
+                        help='Runtime lidar max range in meters for ray and point-cloud lidar (default: 50)')
+    parser.add_argument('--runtime-lidar-height', type=float, default=1.2,
+                        help='Runtime lidar sensor height in ego-frame meters (default: 1.2)')
+    parser.add_argument('--enable-runtime-point-cloud-lidar', action='store_true',
+                        help='Enable MetaDrive runtime PointCloudLidar and expose it in the unified lidar dict')
+    parser.add_argument('--runtime-point-cloud-lidar-width', type=int, default=200,
+                        help='Runtime PointCloudLidar depth image width (default: 200)')
+    parser.add_argument('--runtime-point-cloud-lidar-height', type=int, default=64,
+                        help='Runtime PointCloudLidar depth image height/channels (default: 64)')
+    parser.add_argument('--runtime-point-cloud-lidar-fov', type=float, default=90.0,
+                        help='Runtime PointCloudLidar FOV in degrees (default: 90)')
+    parser.add_argument('--save-runtime-lidar', action='store_true',
+                        help='Save per-frame runtime_lidar.npz files, PNG debug views, and runtime lidar GIFs')
+
     args = parser.parse_args()
+    if args.save_runtime_lidar and not (args.enable_runtime_lidar or args.enable_runtime_point_cloud_lidar):
+        parser.error('--save-runtime-lidar requires at least one runtime lidar sensor to be enabled')
 
     # Create batch evaluator
     evaluator = BatchEvaluator(
@@ -635,6 +696,15 @@ def main():
         num_groups=args.num_groups,
         num_proposals=args.num_proposals,
         v2_scorer_checkpoint=args.v2_scorer_checkpoint,
+        enable_runtime_lidar=args.enable_runtime_lidar,
+        runtime_lidar_num_lasers=args.runtime_lidar_num_lasers,
+        runtime_lidar_distance=args.runtime_lidar_distance,
+        runtime_lidar_height=args.runtime_lidar_height,
+        enable_runtime_point_cloud_lidar=args.enable_runtime_point_cloud_lidar,
+        runtime_point_cloud_lidar_width=args.runtime_point_cloud_lidar_width,
+        runtime_point_cloud_lidar_height=args.runtime_point_cloud_lidar_height,
+        runtime_point_cloud_lidar_fov=args.runtime_point_cloud_lidar_fov,
+        save_runtime_lidar=args.save_runtime_lidar,
     )
 
     # Run evaluation

--- a/bridgesim/evaluation/core/base_evaluator.py
+++ b/bridgesim/evaluation/core/base_evaluator.py
@@ -28,6 +28,7 @@ from bridgesim.evaluation.utils.epdms_scorer_md import EPDMSScorer
 from bridgesim.evaluation.models.base_adapter import BaseModelAdapter
 from bridgesim.evaluation.core.environment_manager import EnvironmentManager
 from bridgesim.evaluation.utils.constants import VOID, LEFT, RIGHT, STRAIGHT, LANEFOLLOW, CHANGELANELEFT, CHANGELANERIGHT
+from bridgesim.evaluation.utils.lidar_utils import ray_lidar_to_ego_points
 
 
 @contextlib.contextmanager
@@ -91,6 +92,15 @@ class BaseEvaluator:
                  eval_frames: int = None,
                  # scorer_type: str = "legacy",
                  score_start_frame: int = None,
+                 enable_runtime_lidar: bool = False,
+                 runtime_lidar_num_lasers: int = 720,
+                 runtime_lidar_distance: float = 50.0,
+                 runtime_lidar_height: float = 1.2,
+                 enable_runtime_point_cloud_lidar: bool = False,
+                 runtime_point_cloud_lidar_width: int = 200,
+                 runtime_point_cloud_lidar_height: int = 64,
+                 runtime_point_cloud_lidar_fov: float = 90.0,
+                 save_runtime_lidar: bool = False,
                  ):
         """
         Initialize evaluator.
@@ -128,6 +138,15 @@ class BaseEvaluator:
         # self.scorer_type = scorer_type
         # Score start frame: defaults to ego_replay_frames if not specified
         self.score_start_frame = score_start_frame if score_start_frame is not None else self.ego_replay_frames
+        self.enable_runtime_lidar = enable_runtime_lidar
+        self.runtime_lidar_num_lasers = int(runtime_lidar_num_lasers)
+        self.runtime_lidar_distance = float(runtime_lidar_distance)
+        self.runtime_lidar_height = float(runtime_lidar_height)
+        self.enable_runtime_point_cloud_lidar = enable_runtime_point_cloud_lidar
+        self.runtime_point_cloud_lidar_width = int(runtime_point_cloud_lidar_width)
+        self.runtime_point_cloud_lidar_height = int(runtime_point_cloud_lidar_height)
+        self.runtime_point_cloud_lidar_fov = float(runtime_point_cloud_lidar_fov)
+        self.save_runtime_lidar = save_runtime_lidar
 
         assert replan_rate 
 
@@ -450,6 +469,215 @@ class BaseEvaluator:
                 raise
 
         return imgs
+
+
+    def save_runtime_lidar_visualization(self, frame_output_path, lidar_packet, output_name="runtime_lidar_bev.png"):
+        """Save a top-down debug image for one runtime lidar packet."""
+        points = lidar_packet.get('points_ego', np.zeros((0, 3), dtype=np.float32))
+        ray_fractions = lidar_packet.get('ray_fractions', np.zeros((0,), dtype=np.float32))
+        image_size = 700
+        margin = 40
+        center = image_size // 2
+        max_range = max(float(self.runtime_lidar_distance), 1.0)
+        scale = (center - margin) / max_range
+        canvas = np.zeros((image_size, image_size, 3), dtype=np.uint8)
+
+        for radius_m in range(10, int(max_range) + 1, 10):
+            radius_px = int(radius_m * scale)
+            cv2.circle(canvas, (center, center), radius_px, (40, 40, 40), 1)
+            cv2.putText(canvas, f"{radius_m}m", (center + radius_px + 4, center - 4), cv2.FONT_HERSHEY_SIMPLEX, 0.35, (120, 120, 120), 1, cv2.LINE_AA)
+
+        cv2.line(canvas, (center, margin), (center, image_size - margin), (45, 45, 45), 1)
+        cv2.line(canvas, (margin, center), (image_size - margin, center), (45, 45, 45), 1)
+
+        if points.size > 0:
+            valid = np.isfinite(points).all(axis=1)
+            draw_points = points[valid]
+            px = np.round(center - draw_points[:, 1] * scale).astype(np.int32)
+            py = np.round(center - draw_points[:, 0] * scale).astype(np.int32)
+            in_bounds = (px >= 0) & (px < image_size) & (py >= 0) & (py < image_size)
+            canvas[py[in_bounds], px[in_bounds]] = (0, 255, 120)
+
+        cv2.circle(canvas, (center, center), 5, (255, 255, 255), -1)
+        cv2.arrowedLine(canvas, (center, center), (center, center - 45), (255, 255, 255), 2, tipLength=0.25)
+        cv2.putText(canvas, "+x forward", (center + 8, center - 48), cv2.FONT_HERSHEY_SIMPLEX, 0.45, (220, 220, 220), 1, cv2.LINE_AA)
+        cv2.putText(canvas, "+y left", (margin, center - 8), cv2.FONT_HERSHEY_SIMPLEX, 0.45, (220, 220, 220), 1, cv2.LINE_AA)
+
+        sensor_type = lidar_packet.get("sensor_type", "lidar")
+        ray_fractions = np.asarray(ray_fractions, dtype=np.float32).reshape(-1)
+        if ray_fractions.size > 0:
+            no_hit_count = int(np.sum(ray_fractions >= 0.999))
+            title = f"{sensor_type}: {len(points)} hits, {no_hit_count} max-range rays"
+        else:
+            title = f"{sensor_type}: {len(points)} points"
+        cv2.putText(canvas, title, (20, 28), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255, 255, 255), 1, cv2.LINE_AA)
+        cv2.imwrite(str(frame_output_path / output_name), canvas)
+
+    def save_runtime_point_cloud_sensor_view(self, frame_output_path, lidar_packet):
+        """Render the PointCloudLidar grid as a pure point-cloud sensor image."""
+        point_grid = lidar_packet.get('point_grid_ego')
+        if point_grid is None:
+            return
+
+        grid = np.asarray(point_grid, dtype=np.float32)
+        if grid.ndim != 3 or grid.shape[-1] != 3:
+            return
+
+        height, width = grid.shape[:2]
+        points = grid.reshape(-1, 3)
+        finite = np.isfinite(points).all(axis=1)
+        distance = np.linalg.norm(points[:, :3], axis=1)
+        max_range = max(float(lidar_packet.get('max_range', self.runtime_lidar_distance)), 1.0)
+        valid = finite & (distance > 0.1) & (distance < max_range * 0.98)
+        depth_norm = np.clip(distance / max_range, 0.0, 1.0)
+        # Visualize every valid point by range. Do not use a z-threshold split here;
+        # this view is meant to show whether ground context is present in PointCloudLidar.
+        color_values = ((1.0 - depth_norm) * 255.0).astype(np.uint8)
+        colors = cv2.applyColorMap(color_values.reshape(-1, 1), cv2.COLORMAP_TURBO).reshape(-1, 3)
+
+        canvas = np.zeros((height, width, 3), dtype=np.uint8)
+        canvas.reshape(-1, 3)[valid] = colors[valid]
+        # MetaDrive PointCloudLidar grid rows are opposite normal image coordinates.
+        canvas = np.flipud(canvas)
+        canvas = cv2.resize(canvas, (960, 576), interpolation=cv2.INTER_NEAREST)
+
+        valid_count = int(np.sum(valid))
+        cv2.putText(canvas, f"PointCloudLidar sensor image: {valid_count} valid points", (16, 32), cv2.FONT_HERSHEY_SIMPLEX, 0.72, (245, 245, 245), 1, cv2.LINE_AA)
+        cv2.putText(canvas, "pure point cloud pixels: warm=near, cool=far; no z-threshold coloring", (16, 62), cv2.FONT_HERSHEY_SIMPLEX, 0.48, (210, 210, 210), 1, cv2.LINE_AA)
+        cv2.imwrite(str(frame_output_path / "runtime_point_cloud_lidar_sensor_view.png"), canvas)
+
+    def _capture_runtime_ray_lidar(self, env, frame_id):
+        """Capture MetaDrive 2D physics ray lidar as one unified lidar packet."""
+        lidar_sensor = env.engine.get_sensor('lidar')
+        cloud_points, detected_objects = lidar_sensor.perceive(
+            env.agent,
+            physics_world=env.engine.physics_world.dynamic_world,
+            num_lasers=self.runtime_lidar_num_lasers,
+            distance=self.runtime_lidar_distance,
+            height=self.runtime_lidar_height,
+            show=False,
+        )
+        points = ray_lidar_to_ego_points(
+            cloud_points,
+            num_lasers=self.runtime_lidar_num_lasers,
+            distance=self.runtime_lidar_distance,
+            height=self.runtime_lidar_height,
+        )
+        return {
+            'sensor_name': 'ray_lidar',
+            'sensor_type': 'ray_lidar',
+            'frame': 'ego',
+            'timestamp': frame_id,
+            'points_ego': points,
+            'ray_fractions': np.asarray(cloud_points, dtype=np.float32),
+            'max_range': self.runtime_lidar_distance,
+            'num_lasers': self.runtime_lidar_num_lasers,
+            'height': self.runtime_lidar_height,
+            'num_detected_objects': len(detected_objects) if detected_objects is not None else 0,
+            'metadata': {
+                'source': 'metadrive.component.sensors.lidar.Lidar',
+                'coordinate_frame': 'ego',
+                'description': 'Horizontal MetaDrive physics ray lidar at a fixed sensor height.',
+            },
+        }
+
+    def _capture_runtime_point_cloud_lidar(self, env, frame_id):
+        """Capture MetaDrive depth-rendered point cloud lidar as one unified lidar packet."""
+        sensor = env.engine.get_sensor('point_cloud_lidar')
+        sensor.lens.setFov(self.runtime_point_cloud_lidar_fov)
+        sensor.lens.setFar(self.runtime_lidar_distance)
+        point_grid = sensor.perceive(
+            to_float=True,
+            new_parent_node=env.agent.origin,
+            position=(0.0, 0.0, self.runtime_lidar_height),
+            hpr=(0.0, 0.0, 0.0),
+        )
+        point_grid_sensor = np.asarray(point_grid, dtype=np.float32)
+        point_grid = np.empty_like(point_grid_sensor)
+        point_grid[..., 0] = point_grid_sensor[..., 1]
+        point_grid[..., 1] = -point_grid_sensor[..., 0]
+        point_grid[..., 2] = point_grid_sensor[..., 2] + self.runtime_lidar_height
+
+        points = point_grid.reshape(-1, 3)
+        finite = np.isfinite(points).all(axis=1)
+        points = points[finite]
+        max_range = float(self.runtime_lidar_distance)
+        in_range = np.linalg.norm(points[:, :3], axis=1) <= max_range
+        points = points[in_range]
+        return {
+            'sensor_name': 'point_cloud_lidar',
+            'sensor_type': 'point_cloud_lidar',
+            'frame': 'ego',
+            'timestamp': frame_id,
+            'points_ego': points.astype(np.float32, copy=False),
+            'point_grid_ego': point_grid,
+            'width': self.runtime_point_cloud_lidar_width,
+            'height': self.runtime_point_cloud_lidar_height,
+            'fov': self.runtime_point_cloud_lidar_fov,
+            'max_range': max_range,
+            'metadata': {
+                'source': 'metadrive.component.sensors.point_cloud_lidar.PointCloudLidar',
+                'coordinate_frame': 'ego',
+                'description': 'Depth-camera-derived xyz point grid from MetaDrive PointCloudLidar.',
+            },
+        }
+
+    def perceive_runtime_lidar(self, env, frame_id):
+        """Capture enabled MetaDrive runtime lidar sensors into one unified container."""
+        if not self.enable_runtime_lidar and not self.enable_runtime_point_cloud_lidar:
+            return None
+
+        lidars = {}
+        if self.enable_runtime_lidar:
+            lidars['ray_lidar'] = self._capture_runtime_ray_lidar(env, frame_id)
+        if self.enable_runtime_point_cloud_lidar:
+            lidars['point_cloud_lidar'] = self._capture_runtime_point_cloud_lidar(env, frame_id)
+
+        default_lidar = 'ray_lidar' if 'ray_lidar' in lidars else next(iter(lidars))
+        lidar_data = {
+            'timestamp': frame_id,
+            'frame': 'ego',
+            'default_lidar': default_lidar,
+            'lidars': lidars,
+        }
+
+        if self.save_runtime_lidar:
+            frame_output_path = self.output_dir / f"{frame_id:05d}"
+            frame_output_path.mkdir(parents=True, exist_ok=True)
+            save_payload = {
+                'timestamp': np.asarray([frame_id], dtype=np.int32),
+                'frame': np.asarray([lidar_data['frame']]),
+                'default_lidar': np.asarray([lidar_data['default_lidar']]),
+            }
+            if 'ray_lidar' in lidars:
+                ray_lidar_packet = lidars['ray_lidar']
+                save_payload.update({
+                    'ray_lidar_sensor_type': np.asarray([ray_lidar_packet['sensor_type']]),
+                    'ray_lidar_frame': np.asarray([ray_lidar_packet['frame']]),
+                    'ray_lidar_points_ego': ray_lidar_packet['points_ego'],
+                    'ray_lidar_ray_fractions': ray_lidar_packet['ray_fractions'],
+                    'ray_lidar_max_range': np.asarray([ray_lidar_packet['max_range']], dtype=np.float32),
+                    'ray_lidar_num_lasers': np.asarray([ray_lidar_packet['num_lasers']], dtype=np.int32),
+                    'ray_lidar_height': np.asarray([ray_lidar_packet['height']], dtype=np.float32),
+                    'ray_lidar_num_detected_objects': np.asarray([ray_lidar_packet['num_detected_objects']], dtype=np.int32),
+                })
+                self.save_runtime_lidar_visualization(frame_output_path, ray_lidar_packet)
+            if 'point_cloud_lidar' in lidars:
+                point_cloud_packet = lidars['point_cloud_lidar']
+                save_payload.update({
+                    'point_cloud_lidar_sensor_type': np.asarray([point_cloud_packet['sensor_type']]),
+                    'point_cloud_lidar_frame': np.asarray([point_cloud_packet['frame']]),
+                    'point_cloud_lidar_points_ego': point_cloud_packet['points_ego'],
+                    'point_cloud_lidar_point_grid_ego': point_cloud_packet['point_grid_ego'],
+                    'point_cloud_lidar_width': np.asarray([point_cloud_packet['width']], dtype=np.int32),
+                    'point_cloud_lidar_height': np.asarray([point_cloud_packet['height']], dtype=np.int32),
+                    'point_cloud_lidar_fov': np.asarray([point_cloud_packet['fov']], dtype=np.float32),
+                    'point_cloud_lidar_max_range': np.asarray([point_cloud_packet['max_range']], dtype=np.float32),
+                })
+                self.save_runtime_point_cloud_sensor_view(frame_output_path, point_cloud_packet)
+            np.savez_compressed(frame_output_path / "runtime_lidar.npz", **save_payload)
+
+        return lidar_data
 
     def compute_ego_state(self, env, frame_id, prev_velocity, prev_heading):
         """Compute ego vehicle state in world coordinates."""
@@ -1523,7 +1751,11 @@ class BaseEvaluator:
         # 1. Perceive
         imgs = self.perceive(env, frame_id)
 
-        # 2. Compute ego state
+        # 2. Capture runtime lidar from the current simulated ego pose
+        runtime_lidar_data = self.perceive_runtime_lidar(env, frame_id)
+        self.model_adapter.set_runtime_lidar(runtime_lidar_data)
+
+        # 3. Compute ego state
         ego_state = self.compute_ego_state(env, frame_id, prev_velocity, prev_heading)
 
         # 3. Get navigation waypoint
@@ -1873,7 +2105,13 @@ class BaseEvaluator:
             traffic_mode=self.traffic_mode,
             render=self.enable_vis,
             image_on_cuda=False,
-            agent_policy=agent_policy
+            agent_policy=agent_policy,
+            enable_runtime_lidar=self.enable_runtime_lidar,
+            runtime_lidar_num_lasers=self.runtime_lidar_num_lasers,
+            runtime_lidar_distance=self.runtime_lidar_distance,
+            enable_runtime_point_cloud_lidar=self.enable_runtime_point_cloud_lidar,
+            runtime_point_cloud_lidar_width=self.runtime_point_cloud_lidar_width,
+            runtime_point_cloud_lidar_height=self.runtime_point_cloud_lidar_height,
         )
 
         # Initialize controller based on type, allowing adapters to override
@@ -2128,6 +2366,11 @@ class BaseEvaluator:
                         print("\n[WARNING] No valid EPDMS frames found for closed-loop scoring.")
 
                     self._save_driving_score_summary(df, mean_epdms, route_completion, final_score)
+
+            # Generate runtime lidar GIFs whenever lidar frames were saved.
+            if self.save_runtime_lidar:
+                self.generate_gif(frame_ids, "runtime_lidar_bev.gif", "runtime_lidar_bev.png")
+                self.generate_gif(frame_ids, "runtime_point_cloud_lidar_sensor_view.gif", "runtime_point_cloud_lidar_sensor_view.png")
 
             # Generate GIFs and MP4s from visualizations
             if self.enable_vis:

--- a/bridgesim/evaluation/core/environment_manager.py
+++ b/bridgesim/evaluation/core/environment_manager.py
@@ -5,6 +5,8 @@ Handles traffic mode configuration and environment setup.
 
 from pathlib import Path
 from metadrive.component.sensors.rgb_camera import RGBCamera
+from metadrive.component.sensors.lidar import Lidar
+from metadrive.component.sensors.point_cloud_lidar import PointCloudLidar
 from metadrive.policy.env_input_policy import EnvInputPolicy
 from metadrive.envs.scenario_env import ScenarioEnv
 
@@ -28,12 +30,23 @@ class EnvironmentManager:
         agent_policy: Policy class for the ego agent (default: EnvInputPolicy)
     """
 
-    def __init__(self, scenario_path, traffic_mode="log_replay", render=False, image_on_cuda=True, agent_policy=EnvInputPolicy):
+    def __init__(self, scenario_path, traffic_mode="log_replay", render=False, image_on_cuda=True,
+                 agent_policy=EnvInputPolicy, enable_runtime_lidar=False,
+                 runtime_lidar_num_lasers=720, runtime_lidar_distance=50.0,
+                 enable_runtime_point_cloud_lidar=False,
+                 runtime_point_cloud_lidar_width=200,
+                 runtime_point_cloud_lidar_height=64):
         self.scenario_path = Path(scenario_path)
         self.traffic_mode = traffic_mode
         self.render = render
         self.image_on_cuda = image_on_cuda
         self.agent_policy = agent_policy
+        self.enable_runtime_lidar = enable_runtime_lidar
+        self.runtime_lidar_num_lasers = int(runtime_lidar_num_lasers)
+        self.runtime_lidar_distance = float(runtime_lidar_distance)
+        self.enable_runtime_point_cloud_lidar = enable_runtime_point_cloud_lidar
+        self.runtime_point_cloud_lidar_width = int(runtime_point_cloud_lidar_width)
+        self.runtime_point_cloud_lidar_height = int(runtime_point_cloud_lidar_height)
         self.env = None
 
     def create_env(self):
@@ -68,6 +81,24 @@ class EnvironmentManager:
             "show_fps": False,
             "window_size": (800, 600),
         }
+
+
+        if self.enable_runtime_lidar:
+            config["sensors"]["lidar"] = (Lidar,)
+            config["vehicle_config"]["lidar"] = {
+                "num_lasers": self.runtime_lidar_num_lasers,
+                "distance": self.runtime_lidar_distance,
+                "gaussian_noise": 0.0,
+                "dropout_prob": 0.0,
+            }
+
+        if self.enable_runtime_point_cloud_lidar:
+            config["sensors"]["point_cloud_lidar"] = (
+                PointCloudLidar,
+                self.runtime_point_cloud_lidar_width,
+                self.runtime_point_cloud_lidar_height,
+                True,
+            )
 
         self.env = ScenarioEnv(config)
         return self.env

--- a/bridgesim/evaluation/models/base_adapter.py
+++ b/bridgesim/evaluation/models/base_adapter.py
@@ -32,6 +32,16 @@ class BaseModelAdapter(ABC):
         self.config_path = config_path
         self.model = None
         self.device = "cuda"
+        self.runtime_lidar_data = None
+
+
+    def set_runtime_lidar(self, lidar_data):
+        """Set the current unified runtime lidar container for adapter preprocessing."""
+        self.runtime_lidar_data = lidar_data
+
+    def get_runtime_lidar(self):
+        """Return the current unified runtime lidar container, or None if unavailable."""
+        return self.runtime_lidar_data
 
     @abstractmethod
     def load_model(self):

--- a/bridgesim/evaluation/models/diffusiondrive_adapter.py
+++ b/bridgesim/evaluation/models/diffusiondrive_adapter.py
@@ -17,6 +17,7 @@ from bridgesim.modelzoo.navsim.agents.diffusiondrive.transfuser_config import Tr
 
 from bridgesim.evaluation.models.base_adapter import BaseModelAdapter
 from bridgesim.evaluation.utils.constants import NAVSIM_CMD_MAPPING, DEFAULT_CMD
+from bridgesim.evaluation.utils.lidar_utils import make_lidar_bev
 from bridgesim.utils.camera_utils import NAVSIM_CAM_CONFIGS
 
 
@@ -145,14 +146,8 @@ class DiffusionDriveAdapter(BaseModelAdapter):
         return tensor_image
 
     def _create_lidar_bev(self) -> torch.Tensor:
-        """Create dummy LiDAR BEV representation."""
-        lidar_bev = torch.zeros(
-            self.config.lidar_seq_len,
-            self.config.lidar_resolution_height,
-            self.config.lidar_resolution_width,
-            dtype=torch.float32
-        )
-        return lidar_bev
+        """Create LiDAR BEV from runtime ray lidar when available."""
+        return make_lidar_bev(self.get_runtime_lidar(), self.config, sensor_name="ray_lidar")
 
     def _get_status_feature(self, ego_state: Dict[str, Any], command: int) -> torch.Tensor:
         """

--- a/bridgesim/evaluation/models/diffusiondrivev2_adapter.py
+++ b/bridgesim/evaluation/models/diffusiondrivev2_adapter.py
@@ -17,6 +17,7 @@ from bridgesim.modelzoo.navsim.agents.diffusiondrivev2.diffusiondrivev2_sel_conf
 
 from bridgesim.evaluation.models.base_adapter import BaseModelAdapter
 from bridgesim.evaluation.utils.constants import NAVSIM_CMD_MAPPING, DEFAULT_CMD
+from bridgesim.evaluation.utils.lidar_utils import make_lidar_bev
 from bridgesim.utils.camera_utils import NAVSIM_CAM_CONFIGS
 
 
@@ -188,14 +189,8 @@ class DiffusionDriveV2Adapter(BaseModelAdapter):
         return tensor_image
 
     def _create_lidar_bev(self) -> torch.Tensor:
-        """Create dummy LiDAR BEV representation."""
-        lidar_bev = torch.zeros(
-            self.config.lidar_seq_len,
-            self.config.lidar_resolution_height,
-            self.config.lidar_resolution_width,
-            dtype=torch.float32
-        )
-        return lidar_bev
+        """Create LiDAR BEV from runtime ray lidar when available."""
+        return make_lidar_bev(self.get_runtime_lidar(), self.config, sensor_name="ray_lidar")
 
     def _get_status_feature(self, ego_state: Dict[str, Any], command: int) -> torch.Tensor:
         """

--- a/bridgesim/evaluation/models/transfuser_adapter.py
+++ b/bridgesim/evaluation/models/transfuser_adapter.py
@@ -16,6 +16,7 @@ from bridgesim.modelzoo.navsim.agents.transfuser.transfuser_config import Transf
 
 from bridgesim.evaluation.models.base_adapter import BaseModelAdapter
 from bridgesim.evaluation.utils.constants import NAVSIM_CMD_MAPPING, DEFAULT_CMD
+from bridgesim.evaluation.utils.lidar_utils import make_lidar_bev
 from bridgesim.utils.camera_utils import NAVSIM_CAM_CONFIGS
 
 
@@ -123,15 +124,8 @@ class TransfuserAdapter(BaseModelAdapter):
         return tensor_image
 
     def _create_lidar_bev(self) -> torch.Tensor:
-        """Create dummy LiDAR BEV representation."""
-        # TransFuser expects LiDAR BEV of shape (lidar_seq_len, H, W)
-        lidar_bev = torch.zeros(
-            self.config.lidar_seq_len,
-            self.config.lidar_resolution_height,
-            self.config.lidar_resolution_width,
-            dtype=torch.float32
-        )
-        return lidar_bev
+        """Create LiDAR BEV from runtime ray lidar when available."""
+        return make_lidar_bev(self.get_runtime_lidar(), self.config, sensor_name="ray_lidar")
 
     def _get_status_feature(self, ego_state: Dict[str, Any], command: int) -> torch.Tensor:
         """

--- a/bridgesim/evaluation/unified_evaluator.py
+++ b/bridgesim/evaluation/unified_evaluator.py
@@ -562,11 +562,67 @@ def main():
              "Scoring metrics and route completion are computed only from this frame onwards."
     )
 
+    # Runtime lidar sensors
+    parser.add_argument(
+        "--enable-runtime-lidar",
+        action="store_true",
+        help="Enable MetaDrive runtime ray lidar and expose it in the unified lidar dict"
+    )
+    parser.add_argument(
+        "--runtime-lidar-num-lasers",
+        type=int,
+        default=720,
+        help="Number of MetaDrive runtime ray lidar lasers (default: 720)"
+    )
+    parser.add_argument(
+        "--runtime-lidar-distance",
+        type=float,
+        default=50.0,
+        help="Runtime lidar max range in meters for ray and point-cloud lidar (default: 50)"
+    )
+    parser.add_argument(
+        "--runtime-lidar-height",
+        type=float,
+        default=1.2,
+        help="Runtime lidar sensor height in ego-frame meters (default: 1.2)"
+    )
+    parser.add_argument(
+        "--enable-runtime-point-cloud-lidar",
+        action="store_true",
+        help="Enable MetaDrive runtime PointCloudLidar and expose it in the unified lidar dict"
+    )
+    parser.add_argument(
+        "--runtime-point-cloud-lidar-width",
+        type=int,
+        default=200,
+        help="Runtime PointCloudLidar depth image width (default: 200)"
+    )
+    parser.add_argument(
+        "--runtime-point-cloud-lidar-height",
+        type=int,
+        default=64,
+        help="Runtime PointCloudLidar depth image height/channels (default: 64)"
+    )
+    parser.add_argument(
+        "--runtime-point-cloud-lidar-fov",
+        type=float,
+        default=90.0,
+        help="Runtime PointCloudLidar FOV in degrees (default: 90)"
+    )
+    parser.add_argument(
+        "--save-runtime-lidar",
+        action="store_true",
+        help="Save per-frame runtime_lidar.npz files, PNG debug views, and runtime lidar GIFs"
+    )
+
     args = parser.parse_args()
 
     # Validate arguments
     if args.model_type in ["uniad", "vad"] and not args.config:
         parser.error(f"--config is required for {args.model_type} model")
+
+    if args.save_runtime_lidar and not (args.enable_runtime_lidar or args.enable_runtime_point_cloud_lidar):
+        parser.error("--save-runtime-lidar requires at least one runtime lidar sensor to be enabled")
 
     # Initialize CUDA device
     if args.model_type in ["uniad", "vad"]:
@@ -615,6 +671,15 @@ def main():
         eval_frames=args.eval_frames,
         # scorer_type=args.scorer_type,
         score_start_frame=args.score_start_frame,
+        enable_runtime_lidar=args.enable_runtime_lidar,
+        runtime_lidar_num_lasers=args.runtime_lidar_num_lasers,
+        runtime_lidar_distance=args.runtime_lidar_distance,
+        runtime_lidar_height=args.runtime_lidar_height,
+        enable_runtime_point_cloud_lidar=args.enable_runtime_point_cloud_lidar,
+        runtime_point_cloud_lidar_width=args.runtime_point_cloud_lidar_width,
+        runtime_point_cloud_lidar_height=args.runtime_point_cloud_lidar_height,
+        runtime_point_cloud_lidar_fov=args.runtime_point_cloud_lidar_fov,
+        save_runtime_lidar=args.save_runtime_lidar,
     )
 
     # Run evaluation

--- a/bridgesim/evaluation/utils/lidar_utils.py
+++ b/bridgesim/evaluation/utils/lidar_utils.py
@@ -1,0 +1,152 @@
+"""Runtime lidar helpers for BridgeSim evaluation."""
+
+from typing import Any, Dict, Optional
+
+import numpy as np
+import torch
+
+
+def ray_lidar_to_ego_points(
+    cloud_points,
+    num_lasers: int,
+    distance: float,
+    height: float = 1.2,
+    max_fraction: float = 0.999,
+) -> np.ndarray:
+    """Convert MetaDrive 2D ray-lidar hit fractions into ego-frame xyz points."""
+    ranges = np.asarray(cloud_points, dtype=np.float32).reshape(-1)
+    if ranges.size != num_lasers:
+        num_lasers = ranges.size
+    if num_lasers == 0:
+        return np.zeros((0, 3), dtype=np.float32)
+
+    valid = np.isfinite(ranges) & (ranges >= 0.0) & (ranges < max_fraction)
+    if not np.any(valid):
+        return np.zeros((0, 3), dtype=np.float32)
+
+    angles = np.arange(num_lasers, dtype=np.float32) * (2.0 * np.pi / float(num_lasers))
+    hit_dist = ranges[valid] * float(distance)
+    hit_angles = angles[valid]
+    points = np.stack(
+        [
+            hit_dist * np.cos(hit_angles),
+            hit_dist * np.sin(hit_angles),
+            np.full_like(hit_dist, float(height), dtype=np.float32),
+        ],
+        axis=1,
+    )
+    return points.astype(np.float32, copy=False)
+
+
+def zero_lidar_bev(config: Any) -> torch.Tensor:
+    """Create a zero lidar BEV tensor matching NavSim TransFuser feature layout."""
+    return torch.zeros(
+        int(config.lidar_seq_len),
+        int(config.lidar_resolution_width),
+        int(config.lidar_resolution_height),
+        dtype=torch.float32,
+    )
+
+
+def lidar_points_to_bev(points: np.ndarray, config: Any) -> torch.Tensor:
+    """Rasterize ego-frame xyz points into the TransFuser/DiffusionDrive lidar BEV format."""
+    points = np.asarray(points, dtype=np.float32)
+    if points.size == 0:
+        return zero_lidar_bev(config)
+    points = points.reshape(-1, 3)
+    finite = np.isfinite(points).all(axis=1)
+    points = points[finite]
+    if points.size == 0:
+        return zero_lidar_bev(config)
+
+    max_height = float(getattr(config, "max_height_lidar", 100.0))
+    split_height = float(getattr(config, "lidar_split_height", 0.2))
+    use_ground_plane = bool(getattr(config, "use_ground_plane", False))
+    hist_max = float(getattr(config, "hist_max_per_pixel", 5))
+
+    points = points[points[:, 2] < max_height]
+    if points.size == 0:
+        return zero_lidar_bev(config)
+
+    xbins = np.linspace(
+        float(config.lidar_min_x),
+        float(config.lidar_max_x),
+        int(config.lidar_resolution_width) + 1,
+    )
+    ybins = np.linspace(
+        float(config.lidar_min_y),
+        float(config.lidar_max_y),
+        int(config.lidar_resolution_height) + 1,
+    )
+
+    def splat(point_cloud: np.ndarray) -> np.ndarray:
+        if point_cloud.size == 0:
+            return np.zeros(
+                (int(config.lidar_resolution_width), int(config.lidar_resolution_height)),
+                dtype=np.float32,
+            )
+        hist = np.histogramdd(point_cloud[:, :2], bins=(xbins, ybins))[0].astype(np.float32)
+        hist[hist > hist_max] = hist_max
+        return hist / hist_max
+
+    above = points[points[:, 2] > split_height]
+    above_features = splat(above)
+    if use_ground_plane:
+        below = points[points[:, 2] <= split_height]
+        below_features = splat(below)
+        features = np.stack([below_features, above_features], axis=0)
+    else:
+        features = np.expand_dims(above_features, axis=0)
+
+    expected_channels = int(config.lidar_seq_len)
+    if features.shape[0] < expected_channels:
+        pad = np.zeros((expected_channels - features.shape[0], features.shape[1], features.shape[2]), dtype=np.float32)
+        features = np.concatenate([features, pad], axis=0)
+    elif features.shape[0] > expected_channels:
+        features = features[:expected_channels]
+
+    return torch.from_numpy(features.astype(np.float32, copy=False))
+
+
+def get_lidar_packet(
+    lidar_data: Optional[Dict[str, Any]],
+    sensor_name: Optional[str] = None,
+    sensor_type: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Select one lidar packet from the unified runtime lidar container."""
+    if not lidar_data:
+        return None
+    lidars = lidar_data.get("lidars", {})
+    if not lidars:
+        return None
+
+    if sensor_name is not None:
+        return lidars.get(sensor_name)
+
+    if sensor_type is not None:
+        for packet in lidars.values():
+            if packet.get("sensor_type") == sensor_type:
+                return packet
+        return None
+
+    default_lidar = lidar_data.get("default_lidar")
+    if default_lidar in lidars:
+        return lidars[default_lidar]
+
+    return next(iter(lidars.values()), None)
+
+
+def make_lidar_bev(
+    lidar_data: Optional[Dict[str, Any]],
+    config: Any,
+    sensor_name: Optional[str] = None,
+    sensor_type: Optional[str] = None,
+) -> torch.Tensor:
+    """Return rasterized lidar from the unified runtime lidar container."""
+    packet = get_lidar_packet(lidar_data, sensor_name=sensor_name, sensor_type=sensor_type)
+    if packet is None:
+        return zero_lidar_bev(config)
+    points = packet.get("points_ego")
+    if points is None:
+        return zero_lidar_bev(config)
+    return lidar_points_to_bev(points, config)


### PR DESCRIPTION
## Summary

Adds optional MetaDrive runtime LiDAR support for closed-loop evaluation. This uses simulation-time LiDAR from the current ego pose, not source-dataset LiDAR from ScenarioNet conversion.

## Added

- Runtime `ray_lidar` from MetaDrive `Lidar`
- Runtime `point_cloud_lidar` from MetaDrive `PointCloudLidar`
- Unified runtime LiDAR dict exposed through model adapters
- DiffusionDrive, DiffusionDriveV2, and TransFuser runtime LiDAR BEV input support
- Per-frame `runtime_lidar.npz` saving
- Debug visualizations:
  - `runtime_lidar_bev.gif`
  - `runtime_point_cloud_lidar_sensor_view.gif`
- CLI support in `unified_evaluator.py` and `batch_evaluator.py`
- README usage docs

## New CLI Args

- `--enable-runtime-lidar`
- `--runtime-lidar-num-lasers`
- `--runtime-lidar-distance`
- `--runtime-lidar-height`
- `--enable-runtime-point-cloud-lidar`
- `--runtime-point-cloud-lidar-width`
- `--runtime-point-cloud-lidar-height`
- `--runtime-point-cloud-lidar-fov`
- `--save-runtime-lidar`