### PR TITLE
fix(eval): normalize ego progress against an achievable bound, per NA…

### DIFF
--- a/bridgesim/evaluation/scorers/GT_scorer.py
+++ b/bridgesim/evaluation/scorers/GT_scorer.py
@@ -53,6 +53,23 @@ VEHICLE_POLYGON_COORDS = np.array([
 
 W_PROGRESS, W_TTC, W_LANE_KEEPING, W_HISTORY_COMFORT, W_EXTENDED_COMFORT = 5.0, 5.0, 2.0, 2.0, 2.0
 W_TOTAL = W_PROGRESS + W_TTC + W_LANE_KEEPING + W_HISTORY_COMFORT + W_EXTENDED_COMFORT
+
+# Ego-progress normalisation (NAVSIM, arXiv:2406.15349). Progress is a RATIO to
+# an achievable upper bound, never an absolute distance. This scorer RANKS a
+# candidate set, so it mirrors NAVSIM's proposal-scoring path
+# (``pdm_scorer.py::_aggregate_pdm_scores``) rather than its agent-evaluation
+# path: the bound is the best progress achieved by any non-disqualified
+# candidate in the batch.
+#
+#   masked = progress_raw * (multiplicative_prod > 0)
+#   ep     = clip(progress_raw / max(masked), 0, 1)   if max(masked) > threshold
+#   ep     = 1.0                                       otherwise
+#   ep     = 0.0                                       where prod == 0
+#
+# Below the threshold every candidate is effectively stationary, progress
+# cannot discriminate between them, and forcing it to 1.0 keeps the term
+# neutral instead of penalising physics no candidate can beat.
+PROGRESS_DISTANCE_THRESHOLD_M = 5.0
 LANE_DEVIATION_LIMIT = 0.5
 LANE_KEEPING_WINDOW = 2.0
 TTC_HORIZON = 1.0
@@ -333,7 +350,7 @@ class GTScorer(BaseTrajectoryScorer):
                            red_lanes_per_t: list = None) -> dict:
         metrics = {
             "nc": 1.0, "dac": 1.0, "ddc": 1.0, "tlc": 1.0,
-            "ep": 0.0, "ttc": 1.0, "lk": 1.0, "hc": 1.0, "ec": 1.0
+            "ep": 0.0, "ep_raw_m": 0.0, "ttc": 1.0, "lk": 1.0, "hc": 1.0, "ec": 1.0
         }
 
         # --- Pre-build caches for this candidate ---
@@ -479,12 +496,33 @@ class GTScorer(BaseTrajectoryScorer):
             comfortable = (diff_acc <= EC_ACCEL_THRESH) & (diff_yr <= EC_YAW_RATE_THRESH)
             metrics['ec'] = float(comfortable.sum()) / len(comfortable) if len(comfortable) > 0 else 1.0
 
-        # 8. Progress
+        # 8. Progress, as RAW METRES. Normalisation is batch-relative and so
+        # can only happen once every candidate has been scored; see
+        # ``_normalize_batch_progress``.
         dist = math.sqrt((states['x'][-1] - states['x'][0]) ** 2 +
                          (states['y'][-1] - states['y'][0]) ** 2)
-        metrics['ep'] = min(dist / 30.0, 1.0)
+        metrics['ep_raw_m'] = float(dist)
 
         return metrics
+
+    @staticmethod
+    def _normalize_batch_progress(raw_progress: np.ndarray,
+                                  multi_prods: np.ndarray) -> np.ndarray:
+        """NAVSIM ego progress for a candidate set, normalised batch-relative.
+
+        :param raw_progress: (N,) raw progress per candidate, in metres
+        :param multi_prods: (N,) product of the binary multiplicative metrics;
+            0.0 marks a disqualified candidate
+        :return: (N,) normalised ego progress in [0, 1]
+        """
+        masked = raw_progress * (multi_prods > 0.0)
+        norm_constant = float(masked.max()) if masked.size else 0.0
+        if norm_constant > PROGRESS_DISTANCE_THRESHOLD_M:
+            normalized = np.clip(raw_progress / norm_constant, 0.0, 1.0)
+        else:
+            normalized = np.ones(len(raw_progress), dtype=np.float64)
+        normalized[multi_prods == 0.0] = 0.0
+        return normalized
 
     # ---------------------------------------------------------------
     # Coordinate transforms
@@ -553,7 +591,12 @@ class GTScorer(BaseTrajectoryScorer):
         all_states = self._get_all_trajectory_states(all_paths_sim, self.planner_dt)
 
         # --- Step 5: Score each candidate ---
+        # Two passes: ego progress is normalised against the best candidate in
+        # the batch, so no candidate's score is final until all are measured.
         scores = np.zeros(N)
+        all_metrics = [None] * N
+        raw_progress = np.zeros(N)
+        multi_prods = np.zeros(N)
         for i in range(N):
             # Extract per-candidate states (views, no copy)
             states_i = {
@@ -572,11 +615,19 @@ class GTScorer(BaseTrajectoryScorer):
                 agents_per_t=agents_per_t, red_lanes_per_t=red_lanes_per_t,
             )
 
-            multi_prod = metrics['nc'] * metrics['dac'] * metrics['ddc'] * metrics['tlc']
+            all_metrics[i] = metrics
+            raw_progress[i] = metrics['ep_raw_m']
+            multi_prods[i] = metrics['nc'] * metrics['dac'] * metrics['ddc'] * metrics['tlc']
+
+        # Batch-relative ego progress, then the weighted sum per candidate.
+        ep_normalized = self._normalize_batch_progress(raw_progress, multi_prods)
+        for i in range(N):
+            metrics = all_metrics[i]
+            metrics['ep'] = float(ep_normalized[i])
             weighted_sum = (W_PROGRESS * metrics['ep'] + W_TTC * metrics['ttc'] +
                             W_LANE_KEEPING * metrics['lk'] + W_HISTORY_COMFORT * metrics['hc'] +
                             W_EXTENDED_COMFORT * metrics['ec'])
-            scores[i] = multi_prod * weighted_sum / W_TOTAL
+            scores[i] = multi_prods[i] * weighted_sum / W_TOTAL
 
         best_idx = int(np.argmax(scores))
         self.prev_frame_idx = frame_idx

--- a/bridgesim/evaluation/scorers/TTA_scorer.py
+++ b/bridgesim/evaluation/scorers/TTA_scorer.py
@@ -58,6 +58,19 @@ W_HISTORY_COMFORT = 2.0
 W_EXTENDED_COMFORT = 2.0
 W_TOTAL = W_PROGRESS + W_LANE_KEEPING + W_HISTORY_COMFORT + W_EXTENDED_COMFORT
 
+# Ego-progress normalisation (NAVSIM, arXiv:2406.15349): progress is a RATIO to
+# an achievable upper bound, not an absolute distance.
+#
+# This scorer compares trajectories ACROSS scoring calls -- the retained
+# previous trajectory is scored separately from the new candidate batch, then
+# the two scores are compared to decide whether to replan. A per-call
+# denominator would make those scores incomparable (each trajectory would be
+# normalised against a different bound), so the batch denominator is computed
+# once per decision and threaded explicitly into every score that participates
+# in that comparison. Callers must pass the SAME ``progress_norm_m`` to every
+# score they intend to compare.
+PROGRESS_DISTANCE_THRESHOLD_M = 5.0
+
 LANE_DEVIATION_LIMIT = 0.5
 LANE_KEEPING_WINDOW = 2.0
 STOPPED_SPEED_THRESHOLD = 5e-2
@@ -380,7 +393,7 @@ class TTAScorer(BaseTrajectoryScorer):
                            red_lanes_per_t: list = None) -> dict:
         metrics = {
             "col": 1.0, "dac": 1.0, "ddc": 1.0, "tlc": 1.0,
-            "ep": 0.0, "lk": 1.0, "hc": 1.0, "ec": 1.0
+            "ep": 0.0, "ep_raw_m": 0.0, "lk": 1.0, "hc": 1.0, "ec": 1.0
         }
 
         ego_polys = [self._get_ego_polygon(states['x'][t], states['y'][t], states['heading'][t])
@@ -554,10 +567,12 @@ class TTAScorer(BaseTrajectoryScorer):
             comfortable = (diff_acc <= EC_ACCEL_THRESH) & (diff_yr <= EC_YAW_RATE_THRESH)
             metrics['ec'] = float(comfortable.sum()) / len(comfortable) if len(comfortable) > 0 else 1.0
 
-        # 8. Progress
+        # 8. Progress, as RAW METRES. Normalisation needs a denominator shared
+        # across every trajectory being compared, so it happens in
+        # ``_metrics_to_score``.
         dist = math.sqrt((states['x'][-1] - states['x'][0]) ** 2 +
                          (states['y'][-1] - states['y'][0]) ** 2)
-        metrics['ep'] = min(dist / 3.0, 1.0)
+        metrics['ep_raw_m'] = float(dist)
 
         return metrics
 
@@ -566,9 +581,36 @@ class TTAScorer(BaseTrajectoryScorer):
     # ---------------------------------------------------------------
 
     @staticmethod
-    def _metrics_to_score(metrics: dict) -> float:
-        """Convert metrics dict to scalar score."""
+    def _normalize_progress(raw_m: float, multi_prod: float,
+                            norm_m: float) -> float:
+        """NAVSIM ego progress for one trajectory against a shared bound.
+
+        :param raw_m: this trajectory's raw progress in metres
+        :param multi_prod: product of the binary multiplicative metrics;
+            0.0 disqualifies the trajectory
+        :param norm_m: the shared denominator in metres (see
+            :data:`PROGRESS_DISTANCE_THRESHOLD_M`)
+        :return: normalised ego progress in [0, 1]
+        """
+        if multi_prod == 0.0:
+            return 0.0
+        denom = max(raw_m, norm_m)
+        if denom > PROGRESS_DISTANCE_THRESHOLD_M:
+            return float(np.clip(raw_m / denom, 0.0, 1.0))
+        return 1.0
+
+    @classmethod
+    def _metrics_to_score(cls, metrics: dict, progress_norm_m: float) -> float:
+        """Convert metrics dict to scalar score.
+
+        :param metrics: per-trajectory metrics, including ``ep_raw_m``
+        :param progress_norm_m: shared ego-progress denominator in metres. Every
+            trajectory whose scores will be COMPARED must be passed the same
+            value, otherwise the comparison is between different scales.
+        """
         multi_prod = metrics['col'] * metrics['dac'] * metrics['ddc'] * metrics['tlc']
+        metrics['ep'] = cls._normalize_progress(
+            metrics.get('ep_raw_m', 0.0), multi_prod, progress_norm_m)
         weighted_sum = (W_PROGRESS * metrics['ep'] +
                         W_LANE_KEEPING * metrics['lk'] +
                         W_HISTORY_COMFORT * metrics['hc'] +
@@ -582,11 +624,15 @@ class TTAScorer(BaseTrajectoryScorer):
         ego_state: Dict[str, Any],
         n_execute: Optional[int],
         agents_per_t: list = None,
+        *,
+        progress_norm_m: float,
     ) -> float:
         """
         Score one candidate trajectory in world frame at current replan time.
 
         Args:
+            progress_norm_m: Shared ego-progress denominator in metres. Pass the
+                same value to every trajectory whose scores are compared.
             traj_world: (T, 2) future waypoints in world frame (no current point).
             frame_idx: Current scenario frame index.
             ego_state: Current ego state dict.
@@ -623,7 +669,7 @@ class TTAScorer(BaseTrajectoryScorer):
             agents_per_t=trimmed_agents,
             red_lanes_per_t=red_lanes_per_t,
         )
-        return self._metrics_to_score(metrics)
+        return self._metrics_to_score(metrics, progress_norm_m)
 
     # ---------------------------------------------------------------
     # Interpolation helper
@@ -759,7 +805,15 @@ class TTAScorer(BaseTrajectoryScorer):
 
         all_states = self._get_all_trajectory_states(all_paths_sim, self.planner_dt)
 
+        # Two passes: the ego-progress denominator is the best progress any
+        # non-disqualified candidate achieves, so no score is final until every
+        # candidate has been measured. The same denominator is then reused for
+        # the retained-trajectory comparison below, keeping all scores that get
+        # compared on one scale.
         scores = np.zeros(N)
+        all_metrics = [None] * N
+        raw_progress = np.zeros(N)
+        multi_prods = np.zeros(N)
         for i in range(N):
             states_i = {k: all_states[k][i] for k in all_states}
             metrics = self._calculate_metrics(
@@ -768,7 +822,15 @@ class TTAScorer(BaseTrajectoryScorer):
                 agents_per_t=agents_per_t,
                 red_lanes_per_t=red_lanes_per_t,
             )
-            scores[i] = self._metrics_to_score(metrics)
+            all_metrics[i] = metrics
+            raw_progress[i] = metrics['ep_raw_m']
+            multi_prods[i] = (metrics['col'] * metrics['dac']
+                              * metrics['ddc'] * metrics['tlc'])
+
+        masked_progress = raw_progress * (multi_prods > 0.0)
+        progress_norm_m = float(masked_progress.max()) if N else 0.0
+        for i in range(N):
+            scores[i] = self._metrics_to_score(all_metrics[i], progress_norm_m)
 
         # Step 1: Select top-K new candidates by full-horizon score
         top_k = min(5, N)
@@ -816,10 +878,16 @@ class TTAScorer(BaseTrajectoryScorer):
                             ego_state,
                             n_execute,
                             agents_per_t=agents_per_t,
+                            progress_norm_m=progress_norm_m,
                         )
 
                         # Step 2: Re-score top-K new candidates trimmed to same
-                        # horizon as old trajectory for fair comparison
+                        # horizon as old trajectory for fair comparison.
+                        # Both sides of this comparison are short-horizon and
+                        # share the full-batch ``progress_norm_m``. The shared
+                        # bound is what makes them comparable; the absolute
+                        # level is irrelevant because only prev-vs-trimmed is
+                        # compared here, never trimmed-vs-``scores``.
                         best_new_trimmed_score = -1.0
                         for idx in top_new_indices:
                             trimmed_world = candidates_world[idx][:n_planner]
@@ -829,6 +897,7 @@ class TTAScorer(BaseTrajectoryScorer):
                                 ego_state,
                                 n_execute,
                                 agents_per_t=agents_per_t,
+                                progress_norm_m=progress_norm_m,
                             )
                             if trimmed_score > best_new_trimmed_score:
                                 best_new_trimmed_score = trimmed_score

--- a/bridgesim/evaluation/utils/epdms_scorer_md.py
+++ b/bridgesim/evaluation/utils/epdms_scorer_md.py
@@ -20,6 +20,28 @@ VEHICLE_POLYGON_COORDS = np.array([
 
 # Weights & Thresholds
 W_PROGRESS, W_TTC, W_LANE_KEEPING, W_HISTORY_COMFORT, W_EXTENDED_COMFORT = 5.0, 5.0, 2.0, 2.0, 2.0
+
+# Ego-progress normalisation (NAVSIM). Progress is a RATIO against a reference
+# upper bound, not an absolute distance: see NAVSIM (arXiv:2406.15349),
+# "The ego progress subscore represents the agent progress along the route
+# center as a ratio to an approximated safe upper bound [...] The final ratio
+# is clipped to [0, 1] while discarding low or negative progress scores if the
+# upper bound is below 5 meters."
+#
+# Reference implementation this mirrors:
+#   navsim .../score_module/train_pdm_scorer.py::_aggregate_scores
+#     raw       = progress_raw * multiplicative_prod
+#     denom     = maximum(raw, reference_progress)
+#     ep        = raw / denom            where denom  > threshold
+#     ep        = 1.0                    where denom <= threshold
+#     ep        = 0.0                    where denom <= threshold and prod == 0
+#
+# Upstream's reference is PDM-Closed's collision-free progress, cached per
+# scene. This closed-loop scorer has no PDM-Closed rollout, but it already
+# simulates the logged human driver every frame (see ``score_frame``), so the
+# human's raw progress is used as the reference bound. Deviation from NAVSIM is
+# deliberate and documented; see docs note in the commit introducing this.
+PROGRESS_DISTANCE_THRESHOLD_M = 5.0
 LANE_DEVIATION_LIMIT = 0.5  
 LANE_KEEPING_WINDOW = 2.0   
 TTC_HORIZON = 1.0
@@ -185,7 +207,7 @@ class EPDMSScorer:
     def _calculate_metrics(self, states, horizon, frame_idx, role="Agent", prev_states=None):
         metrics = {
             "nc": 1.0, "dac": 1.0, "ddc": 1.0, "tlc": 1.0,
-            "ep": 0.0, "ttc": 1.0, "lk": 1.0, "hc": 1.0, "ec": 1.0
+            "ep": 0.0, "ep_raw_m": 0.0, "ttc": 1.0, "lk": 1.0, "hc": 1.0, "ec": 1.0
         }
         
         # 1. DAC
@@ -342,11 +364,43 @@ class EPDMSScorer:
             if (diff_acc > EC_ACCEL_THRESH or diff_jerk > EC_JERK_THRESH or diff_yr > EC_YAW_RATE_THRESH):
                 metrics['ec'] = 0.0
         
-        # 5. Progress
+        # 5. Progress, as RAW METRES. The normalised ``ep`` in [0, 1] is filled
+        # in by ``score_frame``, which is the only place holding both the agent
+        # and the reference (human) trajectory needed for the denominator.
         dist = np.linalg.norm(np.array([states['x'][-1], states['y'][-1]]) - np.array([states['x'][0], states['y'][0]]))
-        metrics['ep'] = min(dist / 30.0, 1.0)
-        
+        metrics['ep_raw_m'] = float(dist)
+
         return metrics
+
+    @staticmethod
+    def _normalize_progress(agent_raw_m: float, multi_prod: float,
+                            reference_raw_m: float) -> float:
+        """NAVSIM ego-progress: agent progress as a ratio to a safe upper bound.
+
+        Mirrors ``train_pdm_scorer.py::_aggregate_scores`` for a single
+        proposal. ``multi_prod`` masks the agent's progress so a disqualified
+        trajectory cannot earn progress credit, and the denominator is the
+        larger of the (masked) agent progress and the reference bound, so an
+        agent that outperforms the reference scores exactly 1.0 rather than
+        being clipped.
+
+        When the bound is below :data:`PROGRESS_DISTANCE_THRESHOLD_M` no
+        meaningful progress was available at this frame -- typically a
+        standstill or a red light -- and progress is not a useful
+        discriminator, so a qualifying agent receives 1.0 rather than being
+        penalised for physics it cannot beat.
+
+        :param agent_raw_m: agent's raw progress in metres
+        :param multi_prod: product of the binary multiplicative metrics
+            (NC x DAC x DDC x TLC); 0.0 disqualifies the trajectory
+        :param reference_raw_m: reference upper bound in metres
+        :return: normalised ego progress in [0, 1]
+        """
+        masked = agent_raw_m if multi_prod > 0.0 else 0.0
+        denom = max(masked, reference_raw_m)
+        if denom > PROGRESS_DISTANCE_THRESHOLD_M:
+            return float(np.clip(masked / denom, 0.0, 1.0))
+        return 0.0 if multi_prod == 0.0 else 1.0
 
     def score_frame(self, plan_traj: np.ndarray, frame_idx: int) -> Dict[str, float]:
         sdc_track = self.scenario_data['tracks'][self.sdc_id]
@@ -389,7 +443,13 @@ class EPDMSScorer:
         print(f"{'METRIC':<10} | {'AGENT':<5} | {'HUMAN':<5} | {'FINAL':<10}")
         print("-" * 45)
         
-        keys = ['nc', 'dac', 'ddc', 'tlc', 'ep', 'ttc', 'lk', 'hc', 'ec']
+        # ``ep`` is excluded here: the human-penalty filter is defined for the
+        # BINARY metrics (a human violation means the frame is unfair, so the
+        # agent is not penalised). Progress is continuous, and the human is
+        # already accounted for as the reference bound in the normalisation
+        # below -- running it through an ``== 0.0`` test as well would both
+        # double-count the human and almost never fire.
+        keys = ['nc', 'dac', 'ddc', 'tlc', 'ttc', 'lk', 'hc', 'ec']
         for m in keys:
             agent_val = agent_metrics.get(m, 0.0)
             human_val = human_metrics.get(m, 1.0) if human_metrics else "N/A"
@@ -401,7 +461,30 @@ class EPDMSScorer:
             print(f"{m.upper():<10} | {agent_val:.1f}   | {h_str:<5} | {final_val:.1f}")
 
         multi_prod = (final_metrics['nc'] * final_metrics['dac'] * final_metrics['ddc'] * final_metrics['tlc'])
-        weighted_sum = (W_PROGRESS * final_metrics['ep'] + W_TTC * final_metrics['ttc'] + 
+
+        # Ego progress, normalised against the logged human driver as the
+        # reference upper bound (NAVSIM uses PDM-Closed; see the note on
+        # PROGRESS_DISTANCE_THRESHOLD_M). Must follow ``multi_prod``, which
+        # masks a disqualified trajectory's progress to zero.
+        agent_raw_m = float(agent_metrics.get('ep_raw_m', 0.0))
+        # The bound must be SAFE progress: NAVSIM's PDM-Closed reference is
+        # collision- and off-road-free by construction, so a human who gained
+        # distance by running a light must not set a bar the agent is then
+        # measured against. A violating human contributes no bound, which
+        # leaves the agent normalised against itself -- consistent with the
+        # penalty filter above, where a human violation already means this
+        # frame cannot fairly penalise the agent.
+        human_raw_m = 0.0
+        if human_metrics:
+            human_multi = (human_metrics['nc'] * human_metrics['dac']
+                           * human_metrics['ddc'] * human_metrics['tlc'])
+            if human_multi > 0.0:
+                human_raw_m = float(human_metrics.get('ep_raw_m', 0.0))
+        final_metrics['ep'] = self._normalize_progress(agent_raw_m, multi_prod, human_raw_m)
+        final_metrics['ep_raw_m'] = agent_raw_m
+        print(f"{'EP':<10} | {agent_raw_m:.1f}m  | {human_raw_m:.1f}m  | {final_metrics['ep']:.1f}")
+
+        weighted_sum = (W_PROGRESS * final_metrics['ep'] + W_TTC * final_metrics['ttc'] +
                         W_LANE_KEEPING * final_metrics['lk'] + W_HISTORY_COMFORT * final_metrics['hc'] + 
                         W_EXTENDED_COMFORT * final_metrics['ec'])
         weighted_avg = weighted_sum / (W_PROGRESS + W_TTC + W_LANE_KEEPING + W_HISTORY_COMFORT + W_EXTENDED_COMFORT)

--- a/tests/test_ego_progress_normalization.py
+++ b/tests/test_ego_progress_normalization.py
@@ -1,0 +1,244 @@
+"""Ego-progress normalisation, across the three BridgeSim scorers.
+
+NAVSIM (arXiv:2406.15349) defines ego progress as a RATIO to an achievable
+upper bound, not an absolute distance:
+
+    "The ego progress subscore represents the agent progress along the route
+    center as a ratio to an approximated safe upper bound [...] The final ratio
+    is clipped to [0, 1] while discarding low or negative progress scores if
+    the upper bound is below 5 meters."
+
+These tests pin the two variants BridgeSim needs:
+
+* ``EPDMSScorer``  -- reported metric, one trajectory scored against a
+  reference bound (NAVSIM's agent-evaluation path).
+* ``GTScorer`` / ``TTAScorer`` -- candidate rankers, normalised against the
+  best candidate in the batch (NAVSIM's proposal-scoring path).
+
+The scorer modules are loaded directly from source: importing them through
+their packages executes ``bridgesim/evaluation/utils/__init__.py``, which pulls
+in metadrive and panda3d. Nothing under test needs either.
+"""
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _install_namespace_stubs():
+    """Register package stubs so submodule imports resolve without __init__."""
+    packages = {
+        "bridgesim": _REPO_ROOT / "bridgesim",
+        "bridgesim.evaluation": _REPO_ROOT / "bridgesim" / "evaluation",
+        "bridgesim.evaluation.scorers": _REPO_ROOT / "bridgesim" / "evaluation" / "scorers",
+        "bridgesim.evaluation.utils": _REPO_ROOT / "bridgesim" / "evaluation" / "utils",
+    }
+    for name, path in packages.items():
+        if name not in sys.modules:
+            module = types.ModuleType(name)
+            module.__path__ = [str(path)]
+            sys.modules[name] = module
+
+
+_install_namespace_stubs()
+
+EPDMS = importlib.import_module("bridgesim.evaluation.utils.epdms_scorer_md")
+GT = importlib.import_module("bridgesim.evaluation.scorers.GT_scorer")
+TTA = importlib.import_module("bridgesim.evaluation.scorers.TTA_scorer")
+
+THRESHOLD = 5.0
+
+
+# ----------------------------------------------------------------------
+# Shared contract: all three scorers agree on the threshold
+# ----------------------------------------------------------------------
+
+def test_all_scorers_share_the_navsim_threshold():
+    """A single threshold, so the three scorers stay mutually comparable."""
+    assert EPDMS.PROGRESS_DISTANCE_THRESHOLD_M == THRESHOLD
+    assert GT.PROGRESS_DISTANCE_THRESHOLD_M == THRESHOLD
+    assert TTA.PROGRESS_DISTANCE_THRESHOLD_M == THRESHOLD
+
+
+# ----------------------------------------------------------------------
+# EPDMSScorer -- reported metric, reference-normalised
+# ----------------------------------------------------------------------
+
+def test_progress_is_a_ratio_to_the_reference():
+    """Half the reference's progress scores half the points."""
+    assert EPDMS.EPDMSScorer._normalize_progress(10.0, 1.0, 20.0) == pytest.approx(0.5)
+
+
+def test_beating_the_reference_saturates_at_one():
+    """The denominator is max(agent, reference), so outperforming caps at 1.0.
+
+    It must not exceed 1.0, and it must not be clipped down to the reference
+    ratio either -- an agent 25% faster than the bound still scores exactly 1.0.
+    """
+    assert EPDMS.EPDMSScorer._normalize_progress(25.0, 1.0, 20.0) == pytest.approx(1.0)
+
+
+def test_disqualified_trajectory_earns_no_progress():
+    """multi_prod == 0 masks progress: a collision cannot buy progress credit."""
+    assert EPDMS.EPDMSScorer._normalize_progress(30.0, 0.0, 20.0) == 0.0
+
+
+def test_standstill_frame_is_not_penalised():
+    """The regression this change exists for.
+
+    At a standstill launch neither the agent nor the reference can cover a
+    meaningful distance, so progress cannot discriminate and must go neutral.
+    Under the previous fixed 30 m normalisation this frame scored 10.5/30 =
+    0.35 and dragged the whole frame's EPDMS down for physics no trajectory
+    could beat.
+    """
+    assert EPDMS.EPDMSScorer._normalize_progress(4.0, 1.0, 4.5) == 1.0
+    # The old behaviour, pinned so a regression is unambiguous.
+    assert min(4.0 / 30.0, 1.0) == pytest.approx(0.1333, abs=1e-4)
+
+
+def test_standstill_does_not_absolve_a_disqualified_trajectory():
+    """Below threshold, a collided trajectory still scores 0, not the neutral 1."""
+    assert EPDMS.EPDMSScorer._normalize_progress(4.0, 0.0, 4.5) == 0.0
+
+
+def test_threshold_boundary_is_strict():
+    """The bound must EXCEED the threshold; exactly 5 m is still 'no progress'."""
+    assert EPDMS.EPDMSScorer._normalize_progress(5.0, 1.0, 5.0) == 1.0
+    just_over = EPDMS.EPDMSScorer._normalize_progress(2.5, 1.0, 5.0 + 1e-6)
+    assert just_over == pytest.approx(0.5, abs=1e-6)
+
+
+def test_zero_progress_against_a_moving_reference_scores_zero():
+    """Stopping when the reference drove 20 m is a real progress failure."""
+    assert EPDMS.EPDMSScorer._normalize_progress(0.0, 1.0, 20.0) == 0.0
+
+
+def test_unsafe_reference_progress_is_not_a_valid_bound():
+    """A human who violated a hard constraint must not set the bar.
+
+    NAVSIM's bound is PDM-Closed progress "without collisions or off-road
+    driving". A logged driver who gained 30 m by running a red light is not a
+    safe upper bound, and an agent that legally covered 12 m must not be
+    scored 0.4 against it. ``score_frame`` drops such a reference to 0.0,
+    which is exercised here through the normalisation contract.
+    """
+    unsafe_bound_dropped = EPDMS.EPDMSScorer._normalize_progress(12.0, 1.0, 0.0)
+    assert unsafe_bound_dropped == pytest.approx(1.0)
+    # Had the unsafe 30 m been kept, the agent would have been punished:
+    assert EPDMS.EPDMSScorer._normalize_progress(12.0, 1.0, 30.0) == pytest.approx(0.4)
+
+
+def test_no_reference_available_falls_back_to_self_normalisation():
+    """With no reference (bound 0), a moving agent is its own bound => 1.0.
+
+    This is the degenerate case where the human trajectory is missing or
+    truncated at the end of a log. It must not crash or divide by zero.
+    """
+    assert EPDMS.EPDMSScorer._normalize_progress(12.0, 1.0, 0.0) == pytest.approx(1.0)
+    assert EPDMS.EPDMSScorer._normalize_progress(0.0, 1.0, 0.0) == 1.0
+
+
+# ----------------------------------------------------------------------
+# GTScorer -- candidate ranker, batch-relative
+# ----------------------------------------------------------------------
+
+def test_batch_best_candidate_scores_one_and_others_are_proportional():
+    raw = np.array([0.0, 4.0, 7.0, 10.0])
+    multi = np.ones(4)
+    ep = GT.GTScorer._normalize_batch_progress(raw, multi)
+    assert ep[3] == pytest.approx(1.0)
+    assert ep == pytest.approx([0.0, 0.4, 0.7, 1.0])
+
+
+def test_disqualified_candidate_cannot_set_the_batch_bound():
+    """A collided candidate that drove furthest must not rescale the others.
+
+    Without masking, the 40 m collided candidate would become the denominator
+    and push the best legal candidate down to 0.25.
+    """
+    raw = np.array([40.0, 10.0, 8.0])
+    multi = np.array([0.0, 1.0, 1.0])
+    ep = GT.GTScorer._normalize_batch_progress(raw, multi)
+    assert ep[0] == 0.0
+    assert ep[1] == pytest.approx(1.0)
+    assert ep[2] == pytest.approx(0.8)
+
+
+def test_batch_below_threshold_goes_neutral():
+    """Every candidate stationary => progress cannot rank them, so all 1.0."""
+    raw = np.array([0.1, 0.5, 2.0])
+    multi = np.ones(3)
+    ep = GT.GTScorer._normalize_batch_progress(raw, multi)
+    assert ep == pytest.approx([1.0, 1.0, 1.0])
+
+
+def test_batch_below_threshold_still_zeroes_disqualified():
+    raw = np.array([0.1, 2.0])
+    multi = np.array([0.0, 1.0])
+    ep = GT.GTScorer._normalize_batch_progress(raw, multi)
+    assert ep[0] == 0.0
+    assert ep[1] == 1.0
+
+
+def test_batch_normalisation_never_leaves_the_unit_interval():
+    rng = np.random.default_rng(0)
+    for _ in range(200):
+        n = int(rng.integers(1, 12))
+        raw = rng.uniform(0.0, 60.0, size=n)
+        multi = (rng.uniform(size=n) > 0.3).astype(float)
+        ep = GT.GTScorer._normalize_batch_progress(raw, multi)
+        assert np.all(ep >= 0.0) and np.all(ep <= 1.0)
+
+
+# ----------------------------------------------------------------------
+# TTAScorer -- shared denominator across comparison stages
+# ----------------------------------------------------------------------
+
+def test_tta_shared_denominator_preserves_ordering():
+    """Two trajectories compared on one bound rank by actual progress."""
+    worse = TTA.TTAScorer._normalize_progress(6.0, 1.0, 12.0)
+    better = TTA.TTAScorer._normalize_progress(12.0, 1.0, 12.0)
+    assert worse == pytest.approx(0.5)
+    assert better == pytest.approx(1.0)
+    assert better > worse
+
+
+def test_tta_per_call_denominators_would_be_incomparable():
+    """Why the denominator is threaded through rather than recomputed.
+
+    Scored against itself, a 6 m trajectory looks identical to a 12 m one.
+    This is the bug the shared ``progress_norm_m`` exists to prevent, and it is
+    pinned here so nobody 'simplifies' the parameter away.
+    """
+    self_normalised_worse = TTA.TTAScorer._normalize_progress(6.0, 1.0, 6.0)
+    self_normalised_better = TTA.TTAScorer._normalize_progress(12.0, 1.0, 12.0)
+    assert self_normalised_worse == self_normalised_better  # both 1.0 -- useless
+
+
+def test_tta_metrics_to_score_uses_the_shared_bound():
+    """``_metrics_to_score`` must fill ``ep`` from raw metres, not read a stale value."""
+    metrics = {
+        "col": 1.0, "dac": 1.0, "ddc": 1.0, "tlc": 1.0,
+        "ep": 0.0, "ep_raw_m": 6.0, "lk": 1.0, "hc": 1.0, "ec": 1.0,
+    }
+    score = TTA.TTAScorer._metrics_to_score(metrics, progress_norm_m=12.0)
+    assert metrics["ep"] == pytest.approx(0.5)
+    expected = (TTA.W_PROGRESS * 0.5 + TTA.W_LANE_KEEPING
+                + TTA.W_HISTORY_COMFORT + TTA.W_EXTENDED_COMFORT) / TTA.W_TOTAL
+    assert score == pytest.approx(expected)
+
+
+def test_tta_disqualified_scores_zero_regardless_of_progress():
+    metrics = {
+        "col": 0.0, "dac": 1.0, "ddc": 1.0, "tlc": 1.0,
+        "ep": 0.0, "ep_raw_m": 30.0, "lk": 1.0, "hc": 1.0, "ec": 1.0,
+    }
+    assert TTA.TTAScorer._metrics_to_score(metrics, progress_norm_m=30.0) == 0.0
+    assert metrics["ep"] == 0.0


### PR DESCRIPTION
Ego progress was computed as an absolute distance ratio against a hardcoded constant -- `min(dist / 30.0, 1.0)` in EPDMSScorer and GTScorer, and `min(dist / 3.0, 1.0)` in TTAScorer. NAVSIM (arXiv:2406.15349) defines EP as a ratio to an approximated safe upper bound, clipped to [0, 1], with progress discarded entirely when that bound falls below 5 metres.

The fixed denominator had two consequences:

* Standstill frames were scored as failures. No trajectory can cover 30 m in a 4 s horizon from rest, so a launch that was already kinematically optimal scored ep ~= 0.35 and dragged down the frame's EPDMS for physics it could not beat. NAVSIM's 5 m threshold exists precisely to neutralize these frames.
* Progress could not compete. With a 30 m denominator the entire achievable spread between candidates was worth less than a single binary term flip, so EP was effectively inert as a ranking signal. TTAScorer's 3 m denominator had the opposite failure: it saturated to 1.0 for anything moving above 0.75 m/s, making EP a near-constant there.

Two variants are needed, mirroring the two paths upstream:

* EPDMSScorer reports a metric for a single trajectory, so it follows NAVSIM's agent-evaluation path (train_pdm_scorer.py): the denominator is max(masked agent progress, reference progress). Upstream's reference is a cached PDM-Closed rollout; this closed-loop scorer has none, but it already simulates the logged human every frame, so the human's progress is used instead. That reference is masked by the human's own multiplicative metrics -- an unsafe human is not a safe upper bound and must not set the bar.
* GTScorer and TTAScorer rank a candidate set, so they follow NAVSIM's proposal-scoring path (pdm_scorer.py): normalize against the best non-disqualified candidate in the batch.

TTAScorer compares a retained trajectory against a fresh candidate batch across separate scoring calls. A per-call denominator would put those scores on different scales, so the batch denominator is computed once per decision and threaded explicitly through every score participating in the comparison; `progress_norm_m` is required rather than defaulted so the footgun is a TypeError instead of a silently wrong replan decision.

This changes every EPDMS number BridgeSim reports. It does not by itself make those numbers comparable to NAVSIM's: the protocol still differs (closed-loop aggregation vs a single non-reactive 4 s rollout through PDMSimulator), and progress is still chord displacement rather than arc length along a route centerline.

Adds tests/ with the first tests for BridgeSim's own code. They load the scorer modules directly from source, since importing them through their packages pulls in metadrive and panda3d.